### PR TITLE
Add a few x64 github actions build tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: PyInstaller test builds
 on: [push]
 
 jobs:
-  build_ubuntu22_glibc2.31:
+  build_ubuntu22_glibc2-31:
 
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,89 @@
+name: PyInstaller test builds
+
+on: [push]
+
+jobs:
+  build_ubuntu22_glibc2.31:
+
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python 3.11 x64
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          architecture: 'x64'
+      - name: Update pip
+        run: python -m pip install --upgrade pip
+      - name: Update builds tools
+        run: python -m pip install --upgrade setuptools wheel
+      - name: Install dependencies
+        run: python -m pip install --upgrade PyQt6 certifi
+      - name: Install PyInstaller
+        run: python -m pip install --upgrade PyInstaller
+      - name: Run pyinst.py
+        run: python3 pyinst.py --no-prompts --onefile --no-upx --no-crt --no-clean --windowed
+      - name: Create archive (.tar.xz)
+        run: tar -cavf Pesterchum_linux64.tar.xz -C dist Pesterchum
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Pesterchum_linux64.tar.xz
+          path: Pesterchum_linux64.tar.xz
+
+  build_win64_latest:
+
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python 3.11 x64
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          architecture: 'x64'
+      - name: Update pip
+        run: python -m pip install --upgrade pip
+      - name: Update builds tools
+        run: python -m pip install --upgrade setuptools wheel
+      - name: Install dependencies
+        run: python -m pip install --upgrade PyQt6 certifi
+      - name: Install PyInstaller
+        run: python -m pip install --upgrade PyInstaller
+      - name: Run PyInstaller
+        run: python3 pyinst.py --no-prompts --onefile --no-upx --crt --no-clean --windowed
+      - name: Create archive (.zip)
+        run: tar.exe -a -c -f Pesterchum_win64.zip -C dist Pesterchum
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Pesterchum_win64.zip
+          path: Pesterchum_win64.zip
+          
+  build_macos64_11:
+
+    runs-on: macos-11
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python 3.11 x64
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          architecture: 'x64'
+      - name: Update pip
+        run: python -m pip install --upgrade pip
+      - name: Update builds tools
+        run: python -m pip install --upgrade setuptools wheel
+      - name: Install dependencies
+        run: python -m pip install --upgrade PyQt6 certifi
+      - name: Install PyInstaller
+        run: python -m pip install --upgrade PyInstaller
+      - name: Run pyinst.py
+        run: python3 pyinst.py --no-prompts --onefile --no-upx --no-crt --no-clean --windowed
+      - name: Create archive (.tar.xz)
+        run: |
+          rm -r dist/Pesterchum
+          mv dist Pesterchum
+          tar -cavf Pesterchum_macOS64.tar.xz Pesterchum
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Pesterchum_macOS64.tar.xz
+          path: Pesterchum_macOS64.tar.xz
+ 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,9 @@ name: PyInstaller test builds
 on: [push]
 
 jobs:
-  build_ubuntu22_glibc2-31:
+  build_ubuntu:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python 3.11 x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,15 +3,15 @@ name: PyInstaller test builds
 on: [push]
 
 jobs:
-  build_ubuntu:
+  build_ubuntu64_20:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Python 3.11 x64
+      - name: Setup Python 3.10 x64
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Update pip
         run: python -m pip install --upgrade pip
@@ -35,10 +35,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Python 3.11 x64
+      - name: Setup Python 3.10 x64
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Update pip
         run: python -m pip install --upgrade pip
@@ -62,10 +62,10 @@ jobs:
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Python 3.11 x64
+      - name: Setup Python 3.10 x64
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Update pip
         run: python -m pip install --upgrade pip
@@ -78,10 +78,7 @@ jobs:
       - name: Run pyinst.py
         run: python3 pyinst.py --no-prompts --onefile --no-upx --no-crt --no-clean --windowed
       - name: Create archive (.tar.xz)
-        run: |
-          rm -r dist/Pesterchum
-          mv dist Pesterchum
-          tar -cavf Pesterchum_macOS64.tar.xz Pesterchum
+        run: tar -cavf Pesterchum_macOS64.tar.xz -C dist Pesterchum.app
       - uses: actions/upload-artifact@v3
         with:
           name: Pesterchum_macOS64.tar.xz


### PR DESCRIPTION
All of these are PyQt6 builds which seem relatively easy to build this way, don't think this'd be as easy for all target systems.

 - For x86 Linux we'd have to install PyQt5 via some other way than pip, as recent PyQt5 don't install via pip with 32 bit architecture, and PyQt6 doesn't support 32 bit systems outright.
 - Win7 targeted builds would ideally also package universal crt somehow.
 - MacOS 10.15 is depreciated and will be removed soon, and building on 10.14/10.15 is required to support them with pyinstaller.