### PR TITLE
fixing pref bug in macOS version

### DIFF
--- a/pesterchum.py
+++ b/pesterchum.py
@@ -3347,7 +3347,7 @@ class PesterWindow(MovingWindow):
             if opvmesssetting != curopvmess:
                 self.config.set("opvMessages", opvmesssetting)
             # animated smiles
-            animatesetting = self.optionmenu.animationscheck.isChecked()
+            animatesetting = self.optionmenu.animationscheck.isChecked() if not ostools.isOSXBundle() else False
             curanimate = self.config.animations()
             if animatesetting != curanimate:
                 self.config.set("animations", animatesetting)

--- a/pesterchum.py
+++ b/pesterchum.py
@@ -3347,7 +3347,10 @@ class PesterWindow(MovingWindow):
             if opvmesssetting != curopvmess:
                 self.config.set("opvMessages", opvmesssetting)
             # animated smiles
-            animatesetting = self.optionmenu.animationscheck.isChecked() if not ostools.isOSXBundle() else False
+            if hasattr(self.optionmenu, "animationscheck"):
+                animatesetting = self.optionmenu.animationscheck.isChecked()
+            else:
+                animatesetting = False
             curanimate = self.config.animations()
             if animatesetting != curanimate:
                 self.config.set("animations", animatesetting)


### PR DESCRIPTION
in macOS, this preference gets skipped in runtime, meaning any preferences following do not save correctly. this includes disabling notifications. adding `if not ostools.isOSXBundle() else False` makes it properly skip this option, allowing preferences that come after to properly save.