### PR TITLE
Enforce select pylint messages

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -11,7 +11,7 @@ analyse-fallback-blocks=no
 
 # In error mode, checkers without error messages are disabled and for others,
 # only the ERROR messages are displayed, and no reports are done by default.
-errors-only=
+#errors-only=
 
 # Always return a 0 (non-error) status code, even if lint errors are found.
 # This is primarily useful in continuous integration scripts.
@@ -31,7 +31,7 @@ extension-pkg-whitelist=
 # Return non-zero exit code if any of these messages/categories are detected,
 # even if score is above --fail-under value. Syntax same as enable. Messages
 # specified are enabled, while categories only check already-enabled messages.
-fail-on=E,F
+fail-on=all
 
 # Specify a score threshold to be exceeded before program exits with error.
 #fail-under=6
@@ -116,7 +116,7 @@ msg-template=
 #output-format=
 
 # Tells whether to display a full report or only the messages.
-reports=yes
+reports=no
 
 # Activate the evaluation score.
 score=no
@@ -142,13 +142,52 @@ confidence=HIGH,
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-#disable=all
+disable=all
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
-#enable=F,E,W
+enable=F, # Fatal
+       E, # Errors
+       # Full groups:
+       unsupported_version,
+       logging,
+       spelling,
+       string,
+       nonascii-checker,
+       # Specific import checks:
+       wildcard-import,
+       # Specific refactoring checks:
+       use-implicit-booleaness-not-len,
+       # Specific basic checks:
+       lost-exception,
+       assert-on-tuple,
+       assert-on-string-literal,
+       self-assigning-variable,
+       comparison-with-callable,
+       nan-comparison,
+       #dangerous-default-value,
+       duplicate-key,
+       duplicate-value,
+       #useless-else-on-loop,
+       expression-not-assigned,
+       confusing-with-statement,
+       unnecessary-lambda,
+       redeclared-assigned-name,
+       pointless-statement,
+       unnecessary-pass,
+       unreachable,
+       eval-used,
+       exec-used,
+       using-constant-test,
+       missing-parentheses-for-call-in-test,
+       comparison-of-constants,
+       literal-comparison,
+       comparison-with-itself,
+       singleton-comparison,
+       #unidiomatic-typecheck,
+
 
 
 [CLASSES]

--- a/convo.py
+++ b/convo.py
@@ -895,7 +895,7 @@ class PesterConvo(QtWidgets.QFrame):
         self.optionsMenu.removeAction(self.blockAction)
 
     def updateColor(self, color):
-        PchumLog.debug("convo updateColor: " + str(color))
+        PchumLog.debug("convo updateColor: %s", color)
         self.chum.color = color
 
     def addMessage(self, msg, me=True):

--- a/dataobjs.py
+++ b/dataobjs.py
@@ -291,15 +291,15 @@ class PesterProfile:
         caps = [l for l in handle if l.isupper()]
         if not caps:
             caps = [""]
-        PchumLog.debug("handle = " + str(handle))
-        PchumLog.debug("caps = " + str(caps))
+        PchumLog.debug("handle = %s", handle)
+        PchumLog.debug("caps = %s", caps)
         # Fallback for invalid string
         try:
             initials = (handle[0] + caps[0]).upper()
         except:
             PchumLog.exception("")
             initials = "XX"
-        PchumLog.debug("initials = " + str(initials))
+        PchumLog.debug("initials = %s", initials)
         if hasattr(self, "time"):
             if time:
                 if self.time > time:

--- a/generic.py
+++ b/generic.py
@@ -145,7 +145,7 @@ class MovingWindow(QtWidgets.QFrame):
         # Assuming everything is supported, we only need this function to call "self.windowHandle().startSystemMove()".
         # If not supported, startSystemMove() returns False and the legacy code runs anyway.
         try:
-            if self.windowHandle().startSystemMove() != True:
+            if not self.windowHandle().startSystemMove():
                 if event.button() == 1:
                     self.moving = event.globalPos() - self.pos()
         except AttributeError as e:

--- a/memos.py
+++ b/memos.py
@@ -1371,7 +1371,7 @@ class PesterMemo(PesterConvo):
                     else:
                         timed = timeProtocol(cmd)
             except:
-                PchumLog.warning("Invalid PESTERCHUM:TIME> " + str(cmd))
+                PchumLog.warning("Invalid PESTERCHUM:TIME> %s", cmd)
                 timed = timedelta(0)
 
         if handle in self.times:
@@ -1414,7 +1414,7 @@ class PesterMemo(PesterConvo):
 
     @QtCore.pyqtSlot(QString, QString)
     def modesUpdated(self, channel, modes):
-        PchumLog.debug(f"modesUpdated(%s, %s)", channel, modes)
+        PchumLog.debug("modesUpdated(%s, %s)", channel, modes)
         if channel.lower() == self.channel.lower():
             self.updateChanModes(modes, None)
 
@@ -1496,8 +1496,8 @@ class PesterMemo(PesterConvo):
         # else:
         #    ttracker = TimeTracker(timedelta(0))
         opchum = PesterProfile(op)
-        PchumLog.debug("op = " + op)
-        PchumLog.debug("opchum = " + opchum.handle)
+        PchumLog.debug("op = %s", op)
+        PchumLog.debug("opchum = %s", opchum.handle)
         if op in self.times:
             opgrammar = self.times[op].getGrammar()
         elif op == self.mainwindow.profile().handle:
@@ -1679,7 +1679,7 @@ class PesterMemo(PesterConvo):
                             )
                     except IndexError as e:
                         # This shouldn't happen
-                        PchumLog.warning("kickmsg IndexError: %s" % e)
+                        PchumLog.warning("kickmsg IndexError: %s", e)
                 msgbox.setInformativeText(kick_msg)
                 msgbox.setStandardButtons(
                     QtWidgets.QMessageBox.StandardButton.Ok

--- a/menus.py
+++ b/menus.py
@@ -1026,7 +1026,7 @@ class PesterChooseProfile(QtWidgets.QDialog):
                 "%s is taken already! Pick a new profile." % (collision)
             )
             layout_0.addWidget(collision_warning)
-        elif svsnick != None:
+        elif svsnick is not None:
             svsnick_warning = QtWidgets.QLabel(
                 "Your handle got changed from %s to %s! Pick a new profile." % svsnick
             )

--- a/ostools.py
+++ b/ostools.py
@@ -55,7 +55,7 @@ def validateDataDir():
 
     dirs = [datadir, profile, quirks, logs, errorlogs, backup]
     for d in dirs:
-        if (os.path.isdir(d) == False) or (os.path.exists(d) == False):
+        if not os.path.isdir(d) or not os.path.exists(d):
             os.makedirs(d, exist_ok=True)
 
     # pesterchum.js

--- a/parsetools.py
+++ b/parsetools.py
@@ -460,7 +460,7 @@ def kxsplitMsg(lexed, ctx, fmt="pchum", maxlen=None, debug=False):
     while len(lexed) > 0:
         rounds += 1
         if debug:
-            PchumLog.info(f"[Starting round {rounds}...]")
+            PchumLog.info("[Starting round %s...]", rounds)
         msg = lexed.popleft()
         msglen = 0
         is_text = False
@@ -501,7 +501,7 @@ def kxsplitMsg(lexed, ctx, fmt="pchum", maxlen=None, debug=False):
                     # instead?
                     subround += 1
                     if debug:
-                        PchumLog.info(f"[Splitting round {rounds}-{subround}...]")
+                        PchumLog.info("[Splitting round %s-%s...]", rounds, subround)
                     point = msg.rfind(" ", 0, lenl)
                     if point < 0:
                         # No spaces to break on...ugh. Break at the last space
@@ -514,12 +514,12 @@ def kxsplitMsg(lexed, ctx, fmt="pchum", maxlen=None, debug=False):
                     # Remove what we just added.
                     msg = msg[point:]
                     if debug:
-                        PchumLog.info(f"msg = {msg!r}")
+                        PchumLog.info("msg = %s", msg)
                 else:
                     # Catch the remainder.
                     stack.append(msg)
                     if debug:
-                        PchumLog.info(f"msg caught; stack = {stack!r}")
+                        PchumLog.info("msg caught; stack = %s", stack)
                 # Done processing. Pluck out the first portion so we can
                 # continue processing, clean it up a bit, then add the rest to
                 # our waiting list.
@@ -650,7 +650,7 @@ def kxsplitMsg(lexed, ctx, fmt="pchum", maxlen=None, debug=False):
         # Once we're finally out of things to add, we're, well...out.
         # So add working to the result one last time.
         working = kxpclexer.list_convert(working)
-        if len(working) > 0:
+        if working:  # len > 0
             if debug:
                 print(f"Adding end trails: {working!r}")
             working = "".join(working)
@@ -760,7 +760,7 @@ def kxhandleInput(ctx, text=None, flavor=None):
             msgbox.exec()
             return
 
-    PchumLog.info('--> recv "%s"' % msg)
+    PchumLog.info("--> recv '%s'", msg)
     # karxi: We have a list...but I'm not sure if we ever get anything else, so
     # best to play it safe. I may remove this during later refactoring.
     if isinstance(msg, list):
@@ -791,7 +791,7 @@ def kxhandleInput(ctx, text=None, flavor=None):
     # Put what's necessary in before splitting.
     # Fetch our time if we're producing this for a memo.
     if flavor == "memos":
-        if ctx.time.getTime() == None:
+        if ctx.time.getTime() is None:
             ctx.sendtime()
         grammar = ctx.time.getGrammar()
         # Oh, great...there's a parsing error to work around. Times are added

--- a/pesterchum.py
+++ b/pesterchum.py
@@ -24,7 +24,13 @@ if ostools.isLinux():
 
 # import console
 from pnc.dep.attrdict import AttrDict
-from user_profile import userConfig, userProfile, pesterTheme, PesterLog, PesterProfileDB
+from user_profile import (
+    userConfig,
+    userProfile,
+    pesterTheme,
+    PesterLog,
+    PesterProfileDB,
+)
 from menus import (
     PesterChooseQuirks,
     PesterChooseTheme,
@@ -667,13 +673,10 @@ class chumArea(RightClickTree):
     def showAllChums(self):
         for c in self.chums:
             chandle = c.handle
-            if not len(
-                self.findItems(
-                    chandle,
-                    QtCore.Qt.MatchFlag.MatchExactly
-                    | QtCore.Qt.MatchFlag.MatchRecursive,
-                )
-            ):
+            if not self.findItems(
+                chandle,
+                QtCore.Qt.MatchFlag.MatchExactly | QtCore.Qt.MatchFlag.MatchRecursive,
+            ):  # len is 0
                 # if True:# For if it doesn't work at all :/
                 chumLabel = chumListing(c, self.mainwindow)
                 self.addItem(chumLabel)
@@ -1802,8 +1805,10 @@ class PesterWindow(MovingWindow):
                 (
                     "Possible desync, system time changed by %s "
                     "seconds since last check. abs(%s - %s)"
-                )
-                % (timeDif, currentTime, self.lastCheckPing)
+                ),
+                timeDif,
+                currentTime,
+                self.lastCheckPing,
             )
             self.sincerecv = 80  # Allows 2 more ping attempts before disconnect.
         self.lastCheckPing = time.time()
@@ -2433,8 +2438,8 @@ class PesterWindow(MovingWindow):
                     self.honksound.setSource(
                         QtCore.QUrl.fromLocalFile("themes/honk.wav")
                     )
-        except Exception as err:
-            PchumLog.error(f"Warning: Error loading sounds! ({err!r})")
+        except:
+            PchumLog.exception("Warning: Error loading sounds!")
             self.alarm = NoneSound()
             self.memosound = NoneSound()
             self.namesound = NoneSound()
@@ -2462,7 +2467,7 @@ class PesterWindow(MovingWindow):
                     if self.sound_type == QtMultimedia.QSoundEffect:
                         sound.setVolume(vol)
             except Exception as err:
-                PchumLog.warning(f"Couldn't set volume: {err}")
+                PchumLog.warning("Couldn't set volume: %s", err)
 
     def canSetVolume(self):
         """Returns the state of volume setting capabilities."""
@@ -2648,9 +2653,8 @@ class PesterWindow(MovingWindow):
 
     @QtCore.pyqtSlot(QString, QtGui.QColor)
     def updateColorSlot(self, handle, color):
-        PchumLog.debug("updateColorSlot, " + str(handle) + ", " + str(color))
-        h = str(handle)
-        self.changeColor(h, color)
+        PchumLog.debug("updateColorSlot(%s, %s)", handle, color)
+        self.changeColor(handle, color)
 
     @QtCore.pyqtSlot(QString, QString)
     def deliverMessage(self, handle, msg):
@@ -2675,9 +2679,7 @@ class PesterWindow(MovingWindow):
             msgbox.setStyleSheet(
                 "QMessageBox{ %s }" % self.theme["main/defaultwindow/style"]
             )
-            msgbox.setText(
-                "This chumhandle has been registered; " "you may not use it."
-            )
+            msgbox.setText("This chumhandle has been registered; you may not use it.")
             msgbox.setInformativeText(
                 "Your handle is now being changed to %s." % (changedto)
             )
@@ -3770,7 +3772,7 @@ class PesterWindow(MovingWindow):
         msg = QtWidgets.QMessageBox(self)
         msg.setText("D: TOO MANY PEOPLE!!!")
         msg.setInformativeText(
-            "The server has hit max capacity." "Please try again later."
+            "The server has hit max capacity. Please try again later."
         )
         # msg.setStyleSheet("QMessageBox{" + self.theme["main/defaultwindow/style"] + "}")
         msg.exec()
@@ -3789,7 +3791,7 @@ class PesterWindow(MovingWindow):
         self.irc = irc
 
     def updateServerJson(self):
-        PchumLog.info(self.customServerPrompt_qline.text() + " chosen")
+        PchumLog.info("'%s' chosen.", self.customServerPrompt_qline.text())
         server_and_port = self.customServerPrompt_qline.text().split(":")
         try:
             server = {
@@ -3996,7 +3998,7 @@ class PesterWindow(MovingWindow):
                     self.resetServerlist()
                     return 1
 
-            PchumLog.info(f"server_list_items: {server_list_items}")
+            PchumLog.info("server_list_items: %s", server_list_items)
 
             # Widget 1
             self.chooseRemoveServerWidged = QtWidgets.QDialog()
@@ -4042,7 +4044,7 @@ class PesterWindow(MovingWindow):
             self.chooseRemoveServerWidged.show()
             self.chooseRemoveServerWidged.setFocus()
         else:
-            PchumLog.info(self.serverBox.currentText() + " chosen.")
+            PchumLog.info("'%s' chosen.", self.serverBox.currentText())
 
             with open(_datadir + "serverlist.json") as server_file:
                 read_file = server_file.read()
@@ -4261,8 +4263,8 @@ class MainProgram(QtCore.QObject):
                 windll.shell32.SetCurrentProcessExplicitAppUserModelID(wid)
             except Exception as err:
                 # Log, but otherwise ignore any exceptions.
-                PchumLog.error(f"Failed to set AppUserModel ID: {err}")
-                PchumLog.error(f"Attempted to set as {wid!r}.")
+                PchumLog.error("Failed to set AppUserModel ID: %s", err)
+                PchumLog.error("Attempted to set as %s.", wid)
             # Back to our scheduled program.
 
         self.app = QtWidgets.QApplication(sys.argv)
@@ -4570,7 +4572,7 @@ class MainProgram(QtCore.QObject):
         # Show error to end user and log.
         try:
             # Log to log file
-            PchumLog.error("{}, {}".format(exc, value))
+            PchumLog.error("%s, %s", exc, value)
 
             # Try to write to separate logfile
             try:

--- a/pyinst.py
+++ b/pyinst.py
@@ -147,29 +147,29 @@ if (sys.version_info[0] > 2) and (sys.version_info[1] > 8):
         action=argparse.BooleanOptionalAction,
     )
     _ARGUMENTS = parser.parse_args()
-    if _ARGUMENTS.clean == True:
+    if _ARGUMENTS.clean:
         delete_builddist = "y"
-    elif _ARGUMENTS.clean == False:
+    elif _ARGUMENTS.clean is False:
         delete_builddist = "n"
 
-    if _ARGUMENTS.upx == True:
+    if _ARGUMENTS.upx:
         upx_enabled = "y"
-    elif _ARGUMENTS.upx == False:
+    elif _ARGUMENTS.upx is False:
         upx_enabled = "n"
 
-    if _ARGUMENTS.crt == True:
+    if _ARGUMENTS.crt:
         package_universal_crt = "y"
-    elif _ARGUMENTS.crt == False:
+    elif _ARGUMENTS.crt is False:
         package_universal_crt = "n"
 
-    if _ARGUMENTS.onefile == True:
+    if _ARGUMENTS.onefile:
         onefile = "y"
-    elif _ARGUMENTS.onefile == False:
+    elif _ARGUMENTS.onefile is False:
         onefile = "n"
 
-    if _ARGUMENTS.windowed == True:
+    if _ARGUMENTS.windowed:
         windowed = "y"
-    elif _ARGUMENTS.windowed == False:
+    elif _ARGUMENTS.windowed is False:
         windowed = "n"
 else:
     # Python 3.8 and below
@@ -232,7 +232,7 @@ else:
         windowed = "n"
 
 parser.print_usage()
-if (_ARGUMENTS.prompts != False) and (_ARGUMENTS.prompts != "False"):
+if (_ARGUMENTS.prompts is not False) and (_ARGUMENTS.prompts != "False"):
     try:
         print(
             "This is a script to make building with Pyinstaller a bit more conventient."
@@ -245,7 +245,7 @@ if (_ARGUMENTS.prompts != False) and (_ARGUMENTS.prompts != "False"):
             upx_enabled = input("Enable UPX? (Y/N): ").lower()
         if upx_enabled == "y":
             print("If upx is on your path you don't need to include anything here.")
-            if is_64bit == True:
+            if is_64bit:
                 upx_dir = input("UPX directory [D:\\upx-3.96-win64]: ")
                 if upx_dir == "":
                     upx_dir = "D:\\upx-3.96-win64"  # Default dir for me :)
@@ -269,7 +269,7 @@ if (_ARGUMENTS.prompts != False) and (_ARGUMENTS.prompts != "False"):
                     "Try to include universal CRT? (Y/N): "
                 ).lower()
             if package_universal_crt == "y":
-                if is_64bit == True:
+                if is_64bit:
                     crt_path = input(
                         "Path to universal CRT: [C:\\Program Files (x86)\\Windows Kits\\10\\Redist\\10.0.19041.0\\ucrt\\DLLs\\x64]: "
                     )
@@ -311,12 +311,12 @@ if (_ARGUMENTS.prompts != False) and (_ARGUMENTS.prompts != "False"):
         sys.exit("KeyboardInterrupt")
 else:
     # no-prompt was given
-    if _ARGUMENTS.clean == None:
+    if _ARGUMENTS.clean is None:
         delete_builddist = "n"
-    if _ARGUMENTS.upx == None:
+    if _ARGUMENTS.upx is None:
         upx_enabled = "n"
-    if _ARGUMENTS.crt == None:
-        if is_64bit == True:
+    if _ARGUMENTS.crt is None:
+        if is_64bit:
             crt_path = os.path.join(
                 "C:%s" % os.sep,
                 "Program Files (x86)",
@@ -340,9 +340,9 @@ else:
             )
         print("crt_path = " + crt_path)
         package_universal_crt = "y"
-    if _ARGUMENTS.onefile == None:
+    if _ARGUMENTS.onefile is None:
         onefile = "y"
-    if _ARGUMENTS.windowed == None:
+    if _ARGUMENTS.windowed is None:
         windowed = "y"
 
 if delete_builddist == "y":
@@ -390,7 +390,7 @@ if sys.platform == "win32":
     if package_universal_crt == "y":
         run_win32.append("--paths=%s" % crt_path)
         if os.path.exists(crt_path):
-            if is_64bit == False:
+            if not is_64bit:
                 run_win32.append(
                     "--add-binary=%s\\api-ms-win-core-console-l1-1-0.dll;." % crt_path
                 )
@@ -527,7 +527,7 @@ if sys.platform == "win32":
                     "--add-binary=%s\\api-ms-win-crt-utility-l1-1-0.dll;." % crt_path
                 )
                 run_win32.append("--add-binary=%s\\ucrtbase.dll;." % crt_path)
-            elif is_64bit == True:
+            elif is_64bit:
                 run_win32.append(
                     "--add-binary=%s\\api-ms-win-core-console-l1-1-0.dll;." % crt_path
                 )

--- a/pyquirks.py
+++ b/pyquirks.py
@@ -41,14 +41,13 @@ class PythonQuirks(ScriptQuirks):
                     if not isinstance(obj("test"), str):
                         raise Exception
                 except:
-                    # print("Quirk malformed: %s" % (obj.command))
-                    PchumLog.error("Quirk malformed: %s" % (obj.command))
+                    PchumLog.error("Quirk malformed: %s", obj.command)
 
                     # Since this is executed before QApplication is constructed,
                     # This prevented pesterchum from starting entirely when a quirk was malformed :/
                     # (QWidget: Must construct a QApplication before a QWidget)
 
-                    if QtWidgets.QApplication.instance() != None:
+                    if QtWidgets.QApplication.instance() is not None:
                         msgbox = QtWidgets.QMessageBox()
                         msgbox.setWindowTitle("Error!")
                         msgbox.setText("Quirk malformed: %s" % (obj.command))

--- a/quirks.py
+++ b/quirks.py
@@ -85,9 +85,7 @@ class ScriptQuirks:
                     continue
             except Exception as e:
                 PchumLog.warning(
-                    "Error loading {}: {} (in quirks.py)".format(
-                        os.path.basename(name), e
-                    )
+                    "Error loading %s: %s (in quirks.py)", os.path.basename(name), e
                 )
             else:
                 if self.modHas(module, "setup"):

--- a/randomer.py
+++ b/randomer.py
@@ -78,5 +78,5 @@ class RandomHandler(QtCore.QObject):
                 msgbox.exec()
                 return
             name = str(l[1])
-            PchumLog.info("Random Encounter name is: " + name)
+            PchumLog.info("Random Encounter name is: %s", name)
             self.mainwindow.newConversation(name)

--- a/toast.py
+++ b/toast.py
@@ -85,7 +85,7 @@ class ToastMachine:
                 return self.icon
 
         def importanceM(self, importance=None):
-            if importance != None:
+            if importance:
                 self.importance = importance
             else:
                 return self.importance

--- a/user_profile.py
+++ b/user_profile.py
@@ -203,7 +203,7 @@ with a backup from: <a href='%s'>%s</a></h3></html>"
             # Backup pesterchum.js file.
             # Useful because it seems to randomly get blanked for people.
             backup_path = os.path.join(_datadir, "backup")
-            if os.path.exists(backup_path) == False:
+            if not os.path.exists(backup_path):
                 os.makedirs(backup_path)
             current_backup = datetime.now().day % 5
             shutil.copyfile(
@@ -223,17 +223,17 @@ with a backup from: <a href='%s'>%s</a></h3></html>"
                 "w",
             ) as pzip:
                 for x in profile_list:
-                    if x.endswith(".js") == True:
+                    if x.endswith(".js"):
                         with open(self.filename) as f:
                             pzip.writestr(x, f.read())
 
-            PchumLog.info("Updated backups-%s." % current_backup)
+            PchumLog.info("Updated backups-%s.", current_backup)
         except shutil.Error as e:
-            PchumLog.warning(f"Failed to make backup, shutil error?\n{e}")
+            PchumLog.warning("Failed to make backup, shutil error?\n%s", e)
         except zipfile.BadZipFile as e:
-            PchumLog.warning(f"Failed to make backup, BadZipFile?\n{e}")
+            PchumLog.warning("Failed to make backup, BadZipFile?\n%s", e)
         except OSError as e:
-            PchumLog.warning(f"Failed to make backup, no permission?\n{e}")
+            PchumLog.warning("Failed to make backup, no permission?\n%s", e)
 
     def chums(self):
         if "chums" not in self.config:
@@ -557,7 +557,7 @@ with a backup from: <a href='%s'>%s</a></h3></html>"
                 if filename[l - 3 : l] == ".js":
                     profs.append(filename[0 : l - 3])
         profs.sort()
-        PchumLog.info("Profiles: %s" % str(profs))
+        PchumLog.info("Profiles: %s", profs)
 
         # Validity check
         PchumLog.info("Starting profile check. . .")
@@ -565,12 +565,12 @@ with a backup from: <a href='%s'>%s</a></h3></html>"
             c_profile = os.path.join(profileloc, x + ".js")
             try:
                 json.load(open(c_profile))
-                PchumLog.info(x + ": Pass.")
+                PchumLog.info("%s: Pass.", x)
             except json.JSONDecodeError as e:
-                PchumLog.warning(x + ": Fail.")
+                PchumLog.warning("%s: Fail.", x)
                 PchumLog.warning(e)
                 profs.remove(x)
-                PchumLog.warning(x + " removed from profile list.")
+                PchumLog.warning("%s removed from profile list.", x)
 
                 msgBox = QtWidgets.QMessageBox()
                 msgBox.setIcon(QtWidgets.QMessageBox.Icon.Warning)
@@ -753,7 +753,7 @@ class userProfile:
             for i, m in enumerate(mentions):
                 re.compile(m)
         except re.error as e:
-            PchumLog.error("#{} Not a valid regular expression: {}".format(i, e))
+            PchumLog.error("#%s Not a valid regular expression: %s", i, e)
         else:
             self.mentions = mentions
             self.userprofile["mentions"] = mentions


### PR DESCRIPTION
Enables the following pylint messages in .pylintrc:
```
enable=F, # Fatal
       E, # Errors
       # Full groups:
       unsupported_version,
       logging,
       spelling,
       string,
       nonascii-checker,
       # Specific import checks:
       wildcard-import,
       # Specific refactoring checks:
       use-implicit-booleaness-not-len,
       # Specific basic checks:
       lost-exception,
       assert-on-tuple,
       assert-on-string-literal,
       self-assigning-variable,
       comparison-with-callable,
       nan-comparison,
       #dangerous-default-value,
       duplicate-key,
       duplicate-value,
       #useless-else-on-loop,
       expression-not-assigned,
       confusing-with-statement,
       unnecessary-lambda,
       redeclared-assigned-name,
       pointless-statement,
       unnecessary-pass,
       unreachable,
       eval-used,
       exec-used,
       using-constant-test,
       missing-parentheses-for-call-in-test,
       comparison-of-constants,
       literal-comparison,
       comparison-with-itself,
       singleton-comparison,
       #unidiomatic-typecheck,
```

Also applies the fixes.