### PR TITLE
IRC compatibility toggle

### DIFF
--- a/convo.py
+++ b/convo.py
@@ -1096,7 +1096,12 @@ class PesterConvo(QtWidgets.QFrame):
         text = self.textInput.text()
         text = str(self.textInput.text())
 
-        return parsetools.kxhandleInput(self, text, flavor="convo", irc_compatible=self.mainwindow.config.irc_compatibility_mode())
+        return parsetools.kxhandleInput(
+            self,
+            text,
+            flavor="convo",
+            irc_compatible=self.mainwindow.config.irc_compatibility_mode(),
+        )
 
     @QtCore.pyqtSlot()
     def addThisChum(self):

--- a/convo.py
+++ b/convo.py
@@ -898,7 +898,7 @@ class PesterConvo(QtWidgets.QFrame):
         self.chum.color = color
 
     def addMessage(self, msg, me=True):
-        if type(msg) in [str, str]:
+        if isinstance(msg, str):
             lexmsg = lexMessage(msg)
         else:
             lexmsg = msg
@@ -1096,7 +1096,7 @@ class PesterConvo(QtWidgets.QFrame):
         text = self.textInput.text()
         text = str(self.textInput.text())
 
-        return parsetools.kxhandleInput(self, text, flavor="convo")
+        return parsetools.kxhandleInput(self, text, flavor="convo", irc_compatible=self.mainwindow.config.irc_compatibility_mode())
 
     @QtCore.pyqtSlot()
     def addThisChum(self):

--- a/dataobjs.py
+++ b/dataobjs.py
@@ -321,7 +321,7 @@ class PesterProfile:
 
     def colorcmd(self):
         if self.color:
-            (r, g, b, _) = self.color.getRgb()
+            (r, g, b, _a) = self.color.getRgb()
             return "%d,%d,%d" % (r, g, b)
         else:
             return "0,0,0"

--- a/irc.py
+++ b/irc.py
@@ -862,7 +862,7 @@ class PesterIRC(QtCore.QThread):
             if any(feature.startswith("METADATA") for feature in features):
                 PchumLog.info("Server supports metadata.")
                 self.metadata_supported = True
-                            
+
     def _cap(self, server, nick, subcommand, tag):
         """IRCv3 capabilities command from server.
 

--- a/irc.py
+++ b/irc.py
@@ -829,25 +829,26 @@ class PesterIRC(QtCore.QThread):
         )
         self.connected.emit()  # Alert main thread that we've connected.
         profile = self.mainwindow.profile()
-        if not self.mainwindow.config.lowBandwidth():
-            # Negotiate capabilities
-            self._send_irc.cap("REQ", "message-tags")
-            self._send_irc.cap(
-                "REQ", "draft/metadata-notify-2"
-            )  # <--- Not required in the unreal5 module implementation
-            self._send_irc.cap("REQ", "pesterchum-tag")  # <--- Currently not using this
-            self._send_irc.cap("REQ", "twitch.tv/membership")  # Twitch silly
-            self._send_irc.join("#pesterchum")
-            # Get mood
-            mood = profile.mood.value_str()
-            # Moods via metadata
-            self._send_irc.metadata("*", "sub", "mood")
-            self._send_irc.metadata("*", "set", "mood", mood)
-            # Color via metadata
-            self._send_irc.metadata("*", "sub", "color")
-            self._send_irc.metadata("*", "set", "color", profile.color.name())
-            # Backwards compatible moods
-            self._send_irc.privmsg("#pesterchum", f"MOOD >{mood}")
+        if self.mainwindow.config.irc_compatibility_mode():
+            return
+        # Negotiate capabilities
+        self._send_irc.cap("REQ", "message-tags")
+        self._send_irc.cap(
+            "REQ", "draft/metadata-notify-2"
+        )  # <--- Not required in the unreal5 module implementation
+        self._send_irc.cap("REQ", "pesterchum-tag")  # <--- Currently not using this
+        self._send_irc.cap("REQ", "twitch.tv/membership")  # Twitch silly
+        self._send_irc.join("#pesterchum")
+        # Get mood
+        mood = profile.mood.value_str()
+        # Moods via metadata
+        self._send_irc.metadata("*", "sub", "mood")
+        self._send_irc.metadata("*", "set", "mood", mood)
+        # Color via metadata
+        self._send_irc.metadata("*", "sub", "color")
+        self._send_irc.metadata("*", "set", "color", profile.color.name())
+        # Backwards compatible moods
+        self._send_irc.privmsg("#pesterchum", f"MOOD >{mood}")
 
     def _featurelist(self, _target, _handle, *params):
         """Numerical reply 005 RPL_ISUPPORT to communicate supported server features.
@@ -857,11 +858,11 @@ class PesterIRC(QtCore.QThread):
         """
         features = params[:-1]
         PchumLog.info("Server _featurelist: %s", features)
-        for feature in features:
-            if feature.casefold().startswith("metadata"):
+        if not self.metadata_supported:
+            if any(feature.startswith("METADATA") for feature in features):
                 PchumLog.info("Server supports metadata.")
                 self.metadata_supported = True
-
+                            
     def _cap(self, server, nick, subcommand, tag):
         """IRCv3 capabilities command from server.
 

--- a/memos.py
+++ b/memos.py
@@ -28,7 +28,7 @@ from logviewer import PesterLogViewer
 
 PchumLog = logging.getLogger("pchumLogger")
 _valid_memo_msg_start = re.compile(
-    r"^<c=((\d+,\d+,\d+)|(#([a-fA-F0-9]{6})|(#[a-fA-F0-9]{3})))>[A-Z]{3}:\s"
+    r"^<c=((\d+,\d+,\d+)|(#([a-fA-F0-9]{6})|(#[a-fA-F0-9]{3})))>([A-Z]{3}):\s"
 )
 # Python 3
 QString = str
@@ -361,9 +361,17 @@ class MemoText(PesterText):
 
     def make_valid(self, msg, chum, parent, window, me):
         """Adds initials and color to a message if they're missing."""
-        if not re.match(_valid_memo_msg_start, msg):
+        initials = chum.initials()
+        match = re.match(_valid_memo_msg_start, msg)
+        detected_initials = None
+        if match:
+            try:
+                # Get initials used in msg, check if valid later
+                detected_initials = match.group(6)[1:]
+            except IndexError:
+                pass  # IndexError is fine, just means the initials are invalid
+        if not match or detected_initials != initials:
             if chum is me:
-                initials = me.initials()
                 color = me.colorcmd()
                 msg = f"<c={color}>{initials}: {msg}</c>"
                 msg = addTimeInitial(msg, parent.time.getGrammar())
@@ -374,7 +382,6 @@ class MemoText(PesterText):
                     color = f"{r},{g},{b}"
                 else:
                     color = "0,0,0"
-                initials = chum.initials()
                 msg = f"<c={color}>{initials}: {msg}</c>"
                 msg = addTimeInitial(msg, parent.times[chum.handle].getGrammar())
         return msg

--- a/memos.py
+++ b/memos.py
@@ -357,7 +357,7 @@ class MemoText(PesterText):
             pass
 
     def addMessage(self, msg, chum):
-        if type(msg) in [str, str]:
+        if isinstance(msg, str):
             lexmsg = lexMessage(msg)
         else:
             lexmsg = msg
@@ -698,6 +698,8 @@ class PesterMemo(PesterConvo):
         return PesterIcon(self.mainwindow.theme["memos/memoicon"])
 
     def sendTimeInfo(self, newChum=False):
+        if self.mainwindow.config.irc_compatibility_mode():
+            return
         if newChum:
             self.messageSent.emit(
                 "PESTERCHUM:TIME>%s" % (delta2txt(self.time.getTime(), "server") + "i"),
@@ -1398,7 +1400,7 @@ class PesterMemo(PesterConvo):
     def sentMessage(self):
         text = str(self.textInput.text())
 
-        return parsetools.kxhandleInput(self, text, flavor="memos")
+        return parsetools.kxhandleInput(self, text, flavor="memos", irc_compatible=self.mainwindow.config.irc_compatibility_mode())
 
     @QtCore.pyqtSlot(QString)
     def namesUpdated(self, channel):
@@ -1730,7 +1732,7 @@ class PesterMemo(PesterConvo):
             txt_time = delta2txt(time, "server")
             # Only send if time isn't CURRENT, it's very spammy otherwise.
             # CURRENT should be the default already.
-            if txt_time != "i":
+            if txt_time != "i" and not self.mainwindow.config.irc_compatibility_mode():
                 serverText = "PESTERCHUM:TIME>" + txt_time
                 self.messageSent.emit(serverText, self.title())
         elif update == "+q":
@@ -1951,6 +1953,8 @@ class PesterMemo(PesterConvo):
 
     @QtCore.pyqtSlot()
     def sendtime(self):
+        if self.mainwindow.config.irc_compatibility_mode():
+            return
         # me = self.mainwindow.profile()
         # systemColor = QtGui.QColor(self.mainwindow.theme["memos/systemMsgColor"])
         time = txt2delta(self.timeinput.text())

--- a/menus.py
+++ b/menus.py
@@ -323,7 +323,12 @@ class QuirkTesterWindow(QtWidgets.QDialog):
     def sentMessage(self):
         text = str(self.textInput.text())
 
-        return parsetools.kxhandleInput(self, text, "menus", irc_compatible=self.mainwindow.config.irc_compatibility_mode())
+        return parsetools.kxhandleInput(
+            self,
+            text,
+            "menus",
+            irc_compatible=self.mainwindow.config.irc_compatibility_mode(),
+        )
 
     def addMessage(self, msg, me=True):
         if isinstance(msg, str):
@@ -1238,16 +1243,28 @@ class PesterOptions(QtWidgets.QDialog):
             self.irc_mode_check.setChecked(True)
         bandwidthLabel = QtWidgets.QLabel(
             "Enable this if you're planning on using Pesterchum on a server with normal IRC clients."
-            "\nDisables at least the following features:"
+            "\nStops the client from sending or requesting:"
             "\n - Moods (#pesterchum MOODs and METADATA moods)"
             "\n - Message colors (COLOR > and METADATA color)"
             "\n - Message color tags (<c=0,0,0>)"
             "\n - Timelines (PESTERCHUM:CURRENT, etc.)"
-            "\n - PESTERCHUM:X commands (BEGIN, CEASE, BLOCK, IDLE, etc.)"
+            "\n - Misc. PESTERCHUM:X commands (BEGIN, CEASE, BLOCK, IDLE, etc.)"
         )
         font = bandwidthLabel.font()
         font.setPointSize(8)
         bandwidthLabel.setFont(font)
+
+        self.force_prefix_check = QtWidgets.QCheckBox(
+            "Add initials to memo messages without initials", self
+        )
+        if self.config.force_prefix():
+            self.force_prefix_check.setChecked(True)
+        initials_label = QtWidgets.QLabel(
+            "Enable this when chatting with normal IRC users or to forcibly un-scratch Doc Scratch."
+        )
+        font = initials_label.font()
+        font.setPointSize(8)
+        initials_label.setFont(font)
 
         self.autonickserv = QtWidgets.QCheckBox("Auto-Identify with NickServ", self)
         self.autonickserv.setChecked(parent.userprofile.getAutoIdentify())
@@ -1624,6 +1641,8 @@ class PesterOptions(QtWidgets.QDialog):
         layout_connect.setAlignment(QtCore.Qt.AlignmentFlag.AlignTop)
         layout_connect.addWidget(self.irc_mode_check)
         layout_connect.addWidget(bandwidthLabel)
+        layout_connect.addWidget(self.force_prefix_check)
+        layout_connect.addWidget(initials_label)
         layout_connect.addWidget(self.autonickserv)
         layout_indent = QtWidgets.QVBoxLayout()
         layout_indent.addWidget(self.nickservpass)

--- a/menus.py
+++ b/menus.py
@@ -1226,7 +1226,7 @@ class PesterOptions(QtWidgets.QDialog):
             "Logging",
             "Idle/Updates",
             "Theme",
-            "Connection",
+            "IRC",
         ]
         if parent.advanced:
             self.tabNames.append("Advanced")
@@ -1244,10 +1244,10 @@ class PesterOptions(QtWidgets.QDialog):
         bandwidthLabel = QtWidgets.QLabel(
             "Enable this if you're planning on using Pesterchum on a server with normal IRC clients."
             "\nStops the client from sending or requesting:"
-            "\n - Moods (#pesterchum MOODs and METADATA moods)"
-            "\n - Message colors (COLOR > and METADATA color)"
-            "\n - Message color tags (<c=0,0,0>)"
-            "\n - Timelines (PESTERCHUM:CURRENT, etc.)"
+            "\n - Non-metadata moods (MOOD >0, GETMOOD, etc.)"
+            "\n - Non-metadata dm colors (COLOR >0,0,0)"
+            "\n - Memo message initials and color (<c=0,0,0>EB: </c>)"
+            "\n - Memo timelines"
             "\n - Misc. PESTERCHUM:X commands (BEGIN, CEASE, BLOCK, IDLE, etc.)"
         )
         font = bandwidthLabel.font()
@@ -1255,12 +1255,12 @@ class PesterOptions(QtWidgets.QDialog):
         bandwidthLabel.setFont(font)
 
         self.force_prefix_check = QtWidgets.QCheckBox(
-            "Add initials to memo messages without initials", self
+            "Force all memo messages to have valid initials.", self
         )
         if self.config.force_prefix():
             self.force_prefix_check.setChecked(True)
         initials_label = QtWidgets.QLabel(
-            "Enable this when chatting with normal IRC users or to forcibly un-scratch Doc Scratch."
+            "Disable to allow users to send messages without initials, like Doc Scratch."
         )
         font = initials_label.font()
         font.setPointSize(8)

--- a/menus.py
+++ b/menus.py
@@ -323,10 +323,10 @@ class QuirkTesterWindow(QtWidgets.QDialog):
     def sentMessage(self):
         text = str(self.textInput.text())
 
-        return parsetools.kxhandleInput(self, text, "menus")
+        return parsetools.kxhandleInput(self, text, "menus", irc_compatible=self.mainwindow.config.irc_compatibility_mode())
 
     def addMessage(self, msg, me=True):
-        if type(msg) in [str, str]:
+        if isinstance(msg, str):
             lexmsg = lexMessage(msg)
         else:
             lexmsg = msg
@@ -1233,12 +1233,17 @@ class PesterOptions(QtWidgets.QDialog):
         self.tabs.button(-2).setChecked(True)
         self.pages = QtWidgets.QStackedWidget(self)
 
-        self.bandwidthcheck = QtWidgets.QCheckBox("Low Bandwidth", self)
-        if self.config.lowBandwidth():
-            self.bandwidthcheck.setChecked(True)
+        self.irc_mode_check = QtWidgets.QCheckBox("IRC compatibility mode", self)
+        if self.config.irc_compatibility_mode():
+            self.irc_mode_check.setChecked(True)
         bandwidthLabel = QtWidgets.QLabel(
-            "(Stops you for receiving the flood of MOODS,\n"
-            " though stops chumlist from working properly)"
+            "Enable this if you're planning on using Pesterchum on a server with normal IRC clients."
+            "\nDisables at least the following features:"
+            "\n - Moods (#pesterchum MOODs and METADATA moods)"
+            "\n - Message colors (COLOR > and METADATA color)"
+            "\n - Message color tags (<c=0,0,0>)"
+            "\n - Timelines (PESTERCHUM:CURRENT, etc.)"
+            "\n - PESTERCHUM:X commands (BEGIN, CEASE, BLOCK, IDLE, etc.)"
         )
         font = bandwidthLabel.font()
         font.setPointSize(8)
@@ -1617,7 +1622,7 @@ class PesterOptions(QtWidgets.QDialog):
         widget = QtWidgets.QWidget()
         layout_connect = QtWidgets.QVBoxLayout(widget)
         layout_connect.setAlignment(QtCore.Qt.AlignmentFlag.AlignTop)
-        layout_connect.addWidget(self.bandwidthcheck)
+        layout_connect.addWidget(self.irc_mode_check)
         layout_connect.addWidget(bandwidthLabel)
         layout_connect.addWidget(self.autonickserv)
         layout_indent = QtWidgets.QVBoxLayout()

--- a/parsetools.py
+++ b/parsetools.py
@@ -283,8 +283,7 @@ def kxlexMsg(string):
     # ...and that's it for this.
     return msg
 
-
-def lexMessage(string):
+def lexMessage(string: str):
     lexlist = [
         (mecmd, _mecmdre),
         (colorBegin, _ctag_begin),
@@ -302,10 +301,11 @@ def lexMessage(string):
         (honker, _honk),
     ]
 
-    string = str(string)
     string = string.replace("\n", " ").replace("\r", " ")
-    lexed = lexer(str(string), lexlist)
+    lexed = lexer(string, lexlist)
+    return balance(lexed)
 
+def balance(lexed):
     balanced = []
     beginc = 0
     endc = 0
@@ -683,7 +683,7 @@ def _is_ooc(msg, strict=True):
     return False
 
 
-def kxhandleInput(ctx, text=None, flavor=None):
+def kxhandleInput(ctx, text=None, flavor=None, irc_compatible=False):
     """The function that user input that should be sent to the server is routed
     through. Handles lexing, splitting, and quirk application, as well as
     sending."""
@@ -699,11 +699,10 @@ def kxhandleInput(ctx, text=None, flavor=None):
     if text is None:
         # Fetch the raw text from the input box.
         text = ctx.textInput.text()
-        text = str(ctx.textInput.text())
 
     # Preprocessing stuff.
     msg = text.strip()
-    if msg == "" or msg.startswith("PESTERCHUM:"):
+    if not msg or msg.startswith("PESTERCHUM:"):
         # We don't allow users to send system messages. There's also no
         # point if they haven't entered anything.
         return
@@ -736,7 +735,7 @@ def kxhandleInput(ctx, text=None, flavor=None):
 
     # Begin message processing.
     # We use 'text' despite its lack of processing because it's simpler.
-    if should_quirk and not (is_action or is_ooc):
+    if should_quirk and not (is_action or is_ooc or irc_compatible):
         if flavor != "menus":
             # Fetch the quirks we'll have to apply.
             quirks = ctx.mainwindow.userprofile.quirks
@@ -827,7 +826,8 @@ def kxhandleInput(ctx, text=None, flavor=None):
     if flavor == "convo":
         # if ceased, rebegin
         if hasattr(ctx, "chumopen") and not ctx.chumopen:
-            ctx.mainwindow.newConvoStarted.emit(QString(ctx.title()), True)
+            if not irc_compatible:
+                ctx.mainwindow.newConvoStarted.emit(QString(ctx.title()), True)
             ctx.setChumOpen(True)
 
     # Post-process and send the messages.
@@ -846,7 +846,7 @@ def kxhandleInput(ctx, text=None, flavor=None):
         serverMsg = copy(lm)
 
         # Memo-specific processing.
-        if flavor == "memos" and not is_action:
+        if flavor == "memos" and not is_action and not irc_compatible:
             # Quirks were already applied, so get the prefix/postfix stuff
             # ready.
             # We fetched the information outside of the loop, so just

--- a/parsetools.py
+++ b/parsetools.py
@@ -737,7 +737,7 @@ def kxhandleInput(ctx, text=None, flavor=None, irc_compatible=False):
 
     # Begin message processing.
     # We use 'text' despite its lack of processing because it's simpler.
-    if should_quirk and not (is_action or is_ooc or irc_compatible):
+    if should_quirk and not (is_action or is_ooc):
         if flavor != "menus":
             # Fetch the quirks we'll have to apply.
             quirks = ctx.mainwindow.userprofile.quirks
@@ -846,6 +846,11 @@ def kxhandleInput(ctx, text=None, flavor=None, irc_compatible=False):
         # should be kept to the end because of that, near the emission.
         clientMsg = copy(lm)
         serverMsg = copy(lm)
+
+        # If in IRC-compatible mode, remove color tags.
+        if irc_compatible:
+            serverMsg = re.sub(_ctag_begin, "", serverMsg)
+            serverMsg = re.sub(_ctag_end, "", serverMsg)
 
         # Memo-specific processing.
         if flavor == "memos" and not is_action and not irc_compatible:

--- a/parsetools.py
+++ b/parsetools.py
@@ -283,6 +283,7 @@ def kxlexMsg(string):
     # ...and that's it for this.
     return msg
 
+
 def lexMessage(string: str):
     lexlist = [
         (mecmd, _mecmdre),
@@ -304,6 +305,7 @@ def lexMessage(string: str):
     string = string.replace("\n", " ").replace("\r", " ")
     lexed = lexer(string, lexlist)
     return balance(lexed)
+
 
 def balance(lexed):
     balanced = []

--- a/pesterchum.py
+++ b/pesterchum.py
@@ -1897,9 +1897,10 @@ class PesterWindow(MovingWindow):
         event.accept()
 
     def newMessage(self, handle, msg):
-        if not self.config.irc_compatibility_mode() and handle in self.config.getBlocklist():
+        if handle in self.config.getBlocklist():
             # yeah suck on this
-            self.sendMessage.emit("PESTERCHUM:BLOCKED", handle)
+            if not self.config.irc_compatibility_mode():
+                self.sendMessage.emit("PESTERCHUM:BLOCKED", handle)
             return
         # notify
         if self.config.notifyOptions() & self.config.NEWMSG:
@@ -1951,7 +1952,6 @@ class PesterWindow(MovingWindow):
             # TODO: This is really bad practice. Fix it later.
             return
         memo = self.memos[chan]
-        msg = str(msg)
         if handle not in memo.times:
             # new chum! time current
             newtime = datetime.timedelta(0)
@@ -3442,15 +3442,20 @@ class PesterWindow(MovingWindow):
             curnotify = self.config.notifyOptions()
             if notifysetting != curnotify:
                 self.config.set("notifyOptions", notifysetting)
-            # low bandwidth
+            # IRC compatibility (previously low bandwidth)
             irc_mode_setting = self.optionmenu.irc_mode_check.isChecked()
-            curbandwidth = self.config.irc_compatibility_mode()
-            if irc_mode_setting != curbandwidth:
+            current_irc_mode = self.config.irc_compatibility_mode()
+            if irc_mode_setting != current_irc_mode:
                 self.config.set("irc_compatibility_mode", irc_mode_setting)
                 if irc_mode_setting:
                     self.leftChannel.emit("#pesterchum")
                 else:
                     self.joinChannel.emit("#pesterchum")
+            # Force prefix
+            force_prefix_setting = self.optionmenu.force_prefix_check.isChecked()
+            current_prefix_setting = self.config.force_prefix()
+            if force_prefix_setting != current_prefix_setting:
+                self.config.set("force_prefix", force_prefix_setting)
             # nickserv
             autoidentify = self.optionmenu.autonickserv.isChecked()
             nickservpass = self.optionmenu.nickservpass.text()

--- a/user_profile.py
+++ b/user_profile.py
@@ -361,6 +361,9 @@ with a backup from: <a href='%s'>%s</a></h3></html>"
     def irc_compatibility_mode(self):
         return self.config.get("irc_compatibility_mode", False)
 
+    def force_prefix(self):
+        return self.config.get("force_prefix", False)
+
     def ghostchum(self):
         return self.config.get("ghostchum", False)
 

--- a/user_profile.py
+++ b/user_profile.py
@@ -358,8 +358,8 @@ with a backup from: <a href='%s'>%s</a></h3></html>"
             "notifyOptions", self.SIGNIN | self.NEWMSG | self.NEWCONVO | self.INITIALS
         )
 
-    def lowBandwidth(self):
-        return self.config.get("lowBandwidth", False)
+    def irc_compatibility_mode(self):
+        return self.config.get("irc_compatibility_mode", False)
 
     def ghostchum(self):
         return self.config.get("ghostchum", False)

--- a/user_profile.py
+++ b/user_profile.py
@@ -362,7 +362,7 @@ with a backup from: <a href='%s'>%s</a></h3></html>"
         return self.config.get("irc_compatibility_mode", False)
 
     def force_prefix(self):
-        return self.config.get("force_prefix", False)
+        return self.config.get("force_prefix", True)
 
     def ghostchum(self):
         return self.config.get("ghostchum", False)


### PR DESCRIPTION
- Adds an "IRC compatibility mode" toggle in settings, which stops the clients from sending any Pesterchum-unique syntax/commands. This replaces low latency mode as they both result in leaving the \#pesterchum channel.
- Adds a toggle to force valid initials on all incoming messages, this breaks doc scratch roleplayer text without initials if enabled.
- Renames the 'Connection' tab in options to 'IRC'.

Enabling both of these should make chatting on a normal IRC server with Pesterchum manageable.