### PR TITLE
Use SASL when auto-identifying to NickServ on connect.

### DIFF
--- a/pesterchum.py
+++ b/pesterchum.py
@@ -2545,10 +2545,11 @@ class PesterWindow(MovingWindow):
             self.waitingMessages.answerMessage()
 
     def doAutoIdentify(self):
-        if self.userprofile.getAutoIdentify():
-            self.sendMessage.emit(
-                "identify " + self.userprofile.getNickServPass(), "NickServ"
-            )
+        pass
+        # if self.userprofile.getAutoIdentify():
+        #    self.sendMessage.emit(
+        #        "identify " + self.userprofile.getNickServPass(), "NickServ"
+        #    )
 
     def doAutoJoins(self):
         if not self.autoJoinDone:

--- a/scripts/irc_protocol.py
+++ b/scripts/irc_protocol.py
@@ -176,7 +176,8 @@ class SendIRC:
             sasl_string_base64 = base64.b64encode(sasl_string_bytes).decode(
                 encoding="utf-8"
             )
-            # Woo yeah woo yeah
+            # SASL string needs to be under 400 bytes,
+            # splitting over multiple messages is in the protocol but not implemented here.
             self._send("AUTHENTICATE", text=sasl_string_base64)
 
 

--- a/scripts/irc_protocol.py
+++ b/scripts/irc_protocol.py
@@ -1,5 +1,6 @@
 """IRC-related functions and classes to be imported by irc.py"""
 import logging
+import base64
 
 PchumLog = logging.getLogger("pchumLogger")
 
@@ -41,7 +42,7 @@ class SendIRC:
 
         try:
             PchumLog.debug("Sending: %s", command)
-            self.socket.sendall(outgoing_bytes)
+            self.socket.send(outgoing_bytes)
         except OSError:
             PchumLog.exception("Error while sending: '%s'", command.strip())
             self.socket.close()
@@ -156,6 +157,27 @@ class SendIRC:
     def quit(self, reason=""):
         """Send QUIT to terminate connection."""
         self._send("QUIT", text=reason)
+
+    def authenticate(self, token=None, nick=None, password=None):
+        """Authenticate command for SASL.
+
+        Send either a token like 'PLAIN' or authenticate with nick and password.
+
+        Reference: https://ircv3.net/irc/#account-authentication-and-registration
+        """
+        if token:
+            self._send("AUTHENTICATE", text=token)
+            return
+        if nick and password:
+            # Authentication identity 'nick', authorization identity 'nick' and password 'password'.
+            sasl_string = f"{nick}\x00{nick}\x00{password}"
+            # Encode to use base64, then decode since 'text' only takes str.
+            sasl_string_bytes = sasl_string.encode(encoding="utf-8", errors="replace")
+            sasl_string_base64 = base64.b64encode(sasl_string_bytes).decode(
+                encoding="utf-8"
+            )
+            # Woo yeah woo yeah
+            self._send("AUTHENTICATE", text=sasl_string_base64)
 
 
 def parse_irc_line(line: str):


### PR DESCRIPTION
Adds a basic implementation of the IRCv3.1 SASL specification and the 'PLAIN' authentication mechanism. It's currently not used when switching profile after the connection is established, as support for that is lacking on many IRC servers despite it being allowed in the spec.