### PR TITLE
Only use QtMultimedia.QSoundEffect for audio.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,6 @@ Pesterchum is a Python script. This means that as long as you have Python instal
  - [PyQt6] (prefered) or [PyQt5] (legacy)
      - Qt6 only supports maintained 64 bit operating systems, like Windows 10 or later for Windows. ([Qt 6.3 Supported Platforms](https://doc.qt.io/qt-6/supported-platforms.html))
      - Qt5 supports Windows 7 or later, but is past its EOL for non-commercial use. ([Qt 5.15 Supported Platforms](https://doc.qt.io/qt-6/supported-platforms.html))
- - (Optional) [pygame-ce] or [pygame] can provide an alternative audio backend for certain systems.
-     - Useful for Linux systems that don't meet the Qt6 requirements, as Qt5 Multimedia has a GStreamer dependency.
  - (Optional) [certifi] can provide alternative root certificates for TLS certificate validation.
      - Useful for MacOS, as Python doesn't use the system-provided certificates because of MacOS' outdated SSL library. Also miscellaneous systems without usable root certificates.
  
@@ -102,9 +100,9 @@ Pesterchum is a Python script. This means that as long as you have Python instal
     - On macOS it's also possible to install (a more recent version of) Python via [Brew](https://brew.sh/).
 2. Install Pesterchum's dependencies with pip, run: ``python -m pip install -r requirements.txt``
     - If this fails, try running ``python -m pip install -U pip setuptools wheel`` to update pip, setuptools & wheel and then trying again.
-    - Alternatively, many linux distros also have packages for pyqt and pygame.
-        - Debian: [python3-pyqt6](https://packages.debian.org/testing/python/python3-pyqt6), [python3-pygame](https://packages.debian.org/testing/python/python3-pygame)
-        - Arch: [python-pyqt6](https://archlinux.org/packages/extra/x86_64/python-pyqt6/), [python-pygame](https://archlinux.org/packages/community/x86_64/python-pygame/)
+    - Alternatively, many linux distros also have packages for PyQt6.
+        - Debian: [python3-pyqt6](https://packages.debian.org/testing/python/python3-pyqt6)
+        - Arch: [python-pyqt6](https://archlinux.org/packages/extra/x86_64/python-pyqt6/)
 3. Download [this repository's source](https://github.com/Dpeta/pesterchum-alt-servers/archive/refs/heads/main.zip), or choose the "Source Code" option on any release, and extract the archive to a folder of your choice.
     - Alternatively, clone the repository with git.
 4. Navigate your terminal to the folder you chose with ``cd /folder/you/chose``.
@@ -116,8 +114,6 @@ Pesterchum is a Python script. This means that as long as you have Python instal
 [pip]: https://pypi.org/project/pip/
 [PyQt5]: https://pypi.org/project/PyQt5/
 [PyQt6]: https://pypi.org/project/PyQt6/
-[pygame]: https://pypi.org/project/pygame/
-[pygame-ce]: https://pypi.org/project/pygame-ce/
 [certifi]: https://pypi.org/project/certifi/
 [GStreamer]: https://gstreamer.freedesktop.org/
  

--- a/generic.py
+++ b/generic.py
@@ -160,20 +160,6 @@ class MovingWindow(QtWidgets.QFrame):
             self.moving = None
 
 
-class NoneSound:
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def play(self):
-        pass
-
-    def setVolume(self, v):
-        pass
-
-    def set_volume(self, v):
-        pass
-
-
 class WMButton(QtWidgets.QPushButton):
     def __init__(self, icon, parent=None):
         super().__init__(icon, "", parent)

--- a/menus.py
+++ b/menus.py
@@ -1567,15 +1567,19 @@ class PesterOptions(QtWidgets.QDialog):
         self.audioDeviceBox = QtWidgets.QComboBox(self)
         current_audio_device = self.config.audioDevice()
         active_index = None
-        try:
-            for i, output in enumerate(QtMultimedia.QMediaDevices.audioOutputs()):
-                self.audioDeviceBox.addItem(f"{output.description()}", output.id())
-                if output.id() == current_audio_device:
-                    active_index = i
-            if active_index is not None:
-                self.audioDeviceBox.setCurrentIndex(active_index)
-        except AttributeError:
-            PchumLog.warning("Can't get audio devices, not using PyQt6 QtMultimedia?")
+        if hasattr(QtMultimedia, "QMediaDevices"):
+            # PyQt6
+            try:
+                for i, output in enumerate(QtMultimedia.QMediaDevices.audioOutputs()):
+                    self.audioDeviceBox.addItem(f"{output.description()}", output.id())
+                    if output.id() == current_audio_device:
+                        active_index = i
+                if active_index is not None:
+                    self.audioDeviceBox.setCurrentIndex(active_index)
+            except AttributeError:
+                PchumLog.warning(
+                    "Can't get audio devices, not using PyQt6 QtMultimedia?"
+                )
 
         layout_sound = QtWidgets.QVBoxLayout(widget)
         layout_sound.setAlignment(QtCore.Qt.AlignmentFlag.AlignTop)

--- a/pyinst.py
+++ b/pyinst.py
@@ -9,9 +9,6 @@ import PyInstaller.__main__
 is_64bit = sys.maxsize > 2**32
 # is_linux = sys.platform.startswith("linux")
 exclude_modules = []
-# if is_linux == False:
-#    print("Not Linux, excluding pygame.")
-#    exclude_modules.append('pygame')
 add_data = [
     "quirks;quirks",
     "smilies;smilies",

--- a/requirements-qt5.txt
+++ b/requirements-qt5.txt
@@ -1,5 +1,4 @@
 certifi==2022.12.7
-pygame-ce
 PyQt5==5.15.7
 PyQt5-Qt5==5.15.2
 PyQt5-sip==12.11.0


### PR DESCRIPTION
Using pygame only for audio has always been a tad silly, QtMultimedia should hopefully be manageable despite its quirks while simplifying things.

( + with all current pygame drama this seems like a good time to drop it as a dependency. . . )