### PR TITLE
fix: accessing text when no quirks selected

### DIFF
--- a/menus.py
+++ b/menus.py
@@ -112,6 +112,11 @@ class PesterQuirkList(QtWidgets.QTreeWidget):
 
     @QtCore.pyqtSlot()
     def upShiftQuirk(self):
+        # We cannot move the quirk up if there are no selected quirks,
+        # or if there are none period.
+        if self.currentItem() is None:
+            return
+
         found = self.findItems(
             self.currentItem().text(0), QtCore.Qt.MatchFlag.MatchExactly
         )
@@ -150,6 +155,11 @@ class PesterQuirkList(QtWidgets.QTreeWidget):
 
     @QtCore.pyqtSlot()
     def downShiftQuirk(self):
+        # We cannot move the quirk down if there are no selected quirks,
+        # or if there are none period.
+        if self.currentItem() is None:
+            return
+
         found = self.findItems(
             self.currentItem().text(0), QtCore.Qt.MatchFlag.MatchExactly
         )


### PR DESCRIPTION
 This patch fixes a bug where, in the quirks menu, not having the a quirk selected, or having no quirks defined at all, can lead to the program attempting to access the `text` property of the object returned by `currentItem` on [this line](https://github.com/Dpeta/pesterchum-alt-servers/blob/8fa55951f7b411bf5293e36b6d9bf704592ad44c/menus.py#L116), and [this line](https://github.com/Dpeta/pesterchum-alt-servers/blob/8fa55951f7b411bf5293e36b6d9bf704592ad44c/menus.py#L154).

The `self.currentItem` method will return `None` when there are no selected quirks. This patch exits the method that shifts the quirk groups up or down early if there is none selected. I am very new to this codebase, so if there is something I am not understanding, missing, etc, please do let me know.

Sidenote, might I recommend adding `__pycache__/` to the [.gitignore](https://github.com/Dpeta/pesterchum-alt-servers/blob/main/.gitignore) file?