### PR TITLE
Python 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Python 3.10 x64
+      - name: Setup Python 3.11 x64
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           architecture: 'x64'
       - name: Update pip
         run: python -m pip install --upgrade pip
@@ -33,10 +33,10 @@ jobs:
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Python 3.10 x64
+      - name: Setup Python 3.11 x64
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           architecture: 'x64'
       - name: Update pip
         run: python -m pip install --upgrade pip
@@ -49,11 +49,11 @@ jobs:
       - name: Run PyInstaller
         run: python3 pyinst.py --no-prompts --onefile --no-upx --crt --no-clean --windowed
       - name: Create archive (.zip)
-        run: tar.exe -a -c -f Pesterchum_win64_py310.zip -C dist Pesterchum
+        run: tar.exe -a -c -f Pesterchum_win64_py311.zip -C dist Pesterchum
       - uses: actions/upload-artifact@v3
         with:
-          name: Pesterchum_win64_py310.zip
-          path: Pesterchum_win64_py310.zip
+          name: Pesterchum_win64_py311.zip
+          path: Pesterchum_win64_py311.zip
 
   build_win32_38:
     runs-on: windows-2019
@@ -85,10 +85,10 @@ jobs:
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Python 3.10 x64
+      - name: Setup Python 3.11 x64
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           architecture: 'x64'
       - name: Update pip
         run: python -m pip install --upgrade pip

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Python 3.10 x64
+      - name: Setup Python 3.11 x64
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           architecture: 'x64'
       - name: Install Dependencies
         run: python3 -m pip install PyQt6 certifi PyInstaller

--- a/toast.py
+++ b/toast.py
@@ -107,7 +107,7 @@ class ToastMachine:
             for k, v in self.machine.types.items():
                 if self.machine.type == k:
                     try:
-                        args = inspect.getargspec(v.__init__).args
+                        args = inspect.getfullargspec(v.__init__).args
                     except:
                         args = []
 
@@ -133,7 +133,7 @@ class ToastMachine:
                 if "default" in self.machine.types:
                     if (
                         "parent"
-                        in inspect.getargspec(
+                        in inspect.getfullargspec(
                             self.machine.types["default"].__init__
                         ).args
                     ):


### PR DESCRIPTION
Should be Python 3.11 compatible now

- [Replace deprecated inspect.getargspec with inspect.getfullargspec](https://github.com/Dpeta/pesterchum-alt-servers/commit/97fe88989c3cefb10190e921d99036df9efbef3d)
- [Update workflows to Python 3.11](https://github.com/Dpeta/pesterchum-alt-servers/commit/1f10e255358d13f2977c89afb0eed0e28210c6f0)