### PR TITLE
Allow themes to load custom font files

### DIFF
--- a/parsetools.py
+++ b/parsetools.py
@@ -1107,7 +1107,7 @@ class ThemeException(Exception):
 
 
 def themeChecker(theme):
-    needs = [ 
+    needs = [
         "main/size",
         "main/icon",
         "main/windowtitle",

--- a/parsetools.py
+++ b/parsetools.py
@@ -1107,12 +1107,18 @@ class ThemeException(Exception):
 
 
 def themeChecker(theme):
-    needs = [
+    needs = [ 
         "main/size",
         "main/icon",
         "main/windowtitle",
         "main/style",
+        "main/fonts",
         "main/background-image",
+        "main/sounds/namealarm",
+        "main/sounds/alertsound",
+        "main/sounds/memosound",
+        "main/sounds/ceasesound",
+        "main/sounds/honk",
         "main/menubar/style",
         "main/menu/menuitem",
         "main/menu/style",

--- a/pesterchum.py
+++ b/pesterchum.py
@@ -1992,11 +1992,9 @@ class PesterWindow(MovingWindow):
             self.choosetheme = PesterChooseTheme(self.config, self.theme, self)
             self.choosetheme.exec()
 
-
-
     def initTheme(self, theme):
         # First doing the fonts because any style may depend on it
-        QtGui.QFontDatabase.removeAllApplicationFonts() # GOODBYE previous fonts
+        QtGui.QFontDatabase.removeAllApplicationFonts()  # GOODBYE previous fonts
         QtGui.QFontDatabase.addApplicationFont(
             os.path.join("fonts", "alternian", "AllisDaedric-VYWz.otf")
         )  # haha oops we still need that one!!! for now!! (check `~lisanne "alternian lol" TODO` up above)
@@ -2005,12 +2003,15 @@ class PesterWindow(MovingWindow):
             # ~lisanne : loads fonts from the `main/fonts` key in a theme
             # Note that this wont load fonts from inherited themes
             # that seems fine imo, esp since u could still load them through `$path/../inheritedtheme/somefont.ttf`
-            PchumLog.debug("Loading font "+ font_path)
+            PchumLog.debug("Loading font " + font_path)
             fontID = QtGui.QFontDatabase.addApplicationFont(font_path)
             if fontID == -1:
-                PchumLog.error("Failed loading font: "+font_path)
+                PchumLog.error("Failed loading font: " + font_path)
+                # TODO? Maybe make this spawn an error popup 
             else:
-                PchumLog.debug(f"Font families: {(QtGui.QFontDatabase.applicationFontFamilies(fontID))} (id: {fontID})")
+                PchumLog.debug(
+                    f"Font families: {(QtGui.QFontDatabase.applicationFontFamilies(fontID))} (id: {fontID})"
+                )
 
         self.resize(*theme["main/size"])
         self.setWindowIcon(PesterIcon(theme["main/icon"]))

--- a/pesterchum.py
+++ b/pesterchum.py
@@ -1540,6 +1540,8 @@ class PesterWindow(MovingWindow):
         # Load font
         QtGui.QFontDatabase.addApplicationFont(
             os.path.join("fonts", "alternian", "AllisDaedric-VYWz.otf")
+            # ~lisanne "alternian lol" TODO:  make the parsetools 'alternianTagBegin' lex part use the theme's "main/alternian-font-family" value instead of just assuming "AllisDaedric"
+            # This way themes can change what the alternian font looks like
         )
 
         self.pcUpdate[str, str].connect(self.updateMsg)
@@ -1990,7 +1992,26 @@ class PesterWindow(MovingWindow):
             self.choosetheme = PesterChooseTheme(self.config, self.theme, self)
             self.choosetheme.exec()
 
+
+
     def initTheme(self, theme):
+        # First doing the fonts because any style may depend on it
+        QtGui.QFontDatabase.removeAllApplicationFonts() # GOODBYE previous fonts
+        QtGui.QFontDatabase.addApplicationFont(
+            os.path.join("fonts", "alternian", "AllisDaedric-VYWz.otf")
+        )  # haha oops we still need that one!!! for now!! (check `~lisanne "alternian lol" TODO` up above)
+
+        for font_path in theme["main/fonts"]:
+            # ~lisanne : loads fonts from the `main/fonts` key in a theme
+            # Note that this wont load fonts from inherited themes
+            # that seems fine imo, esp since u could still load them through `$path/../inheritedtheme/somefont.ttf`
+            PchumLog.debug("Loading font "+ font_path)
+            fontID = QtGui.QFontDatabase.addApplicationFont(font_path)
+            if fontID == -1:
+                PchumLog.error("Failed loading font: "+font_path)
+            else:
+                PchumLog.debug(f"Font families: {(QtGui.QFontDatabase.applicationFontFamilies(fontID))} (id: {fontID})")
+
         self.resize(*theme["main/size"])
         self.setWindowIcon(PesterIcon(theme["main/icon"]))
         self.setWindowTitle(theme["main/windowtitle"])

--- a/themes/pesterchum/style.js
+++ b/themes/pesterchum/style.js
@@ -2,6 +2,7 @@
  {"style": "background-repeat: no-repeat;",
   "background-image": "$path/pcbg.png",
   "size": [232, 380],
+  "fonts": [],
   "icon": "$path/trayicon.png",
   "newmsgicon": "$path/trayicon2.png",
   "windowtitle": "PESTERCHUM 6.0",

--- a/user_profile.py
+++ b/user_profile.py
@@ -986,15 +986,15 @@ class pesterTheme(dict):
 
     def pathHook(self, dict):
         # This converts strings containing $path into the proper paths
-        # Honestly ive never even seen this Template stuff before. very funky! 
+        # Honestly ive never even seen this Template stuff before. very funky!
         for key, value in dict.items():
             if isinstance(value, str):
                 templ = Template(value)
                 dict[key] = templ.safe_substitute(path=self.path)
             elif isinstance(value, list):
                 # ~lisanne : for dealing with 'main/fonts' which is an array which contains filepaths with $
-                # probably good to have for future additions 
-                for idx,item in enumerate(value):
+                # probably good to have for future additions
+                for idx, item in enumerate(value):
                     item = value[idx]
                     if isinstance(item, str):
                         # not very DRY of me >:3c

--- a/user_profile.py
+++ b/user_profile.py
@@ -984,12 +984,23 @@ class pesterTheme(dict):
                     raise e
         return v
 
-    def pathHook(self, d):
-        for k, v in d.items():
-            if isinstance(v, str):
-                s = Template(v)
-                d[k] = s.safe_substitute(path=self.path)
-        return d
+    def pathHook(self, dict):
+        # This converts strings containing $path into the proper paths
+        # Honestly ive never even seen this Template stuff before. very funky! 
+        for key, value in dict.items():
+            if isinstance(value, str):
+                templ = Template(value)
+                dict[key] = templ.safe_substitute(path=self.path)
+            elif isinstance(value, list):
+                # ~lisanne : for dealing with 'main/fonts' which is an array which contains filepaths with $
+                # probably good to have for future additions 
+                for idx,item in enumerate(value):
+                    item = value[idx]
+                    if isinstance(item, str):
+                        # not very DRY of me >:3c
+                        templ = Template(item)
+                        value[idx] = templ.safe_substitute(path=self.path)
+        return dict
 
     def get(self, key, default):
         keys = key.split("/")


### PR DESCRIPTION
Allows themes to load included fonts by putting the filenames in an array under the `main/fonts` key
I.E.:
```json
{
  "main": {
    "fonts" : [
      "$path/myfont.otf"
     ]
   }
}
```
They can then be used like normal in the QSS styles  

One thing to note is that if this key exists *and* the theme inherits from another, the inherited theme's fonts do not get loaded,
so if `theme B` inherits from `theme A`, and `theme A` lists fonts `["$path/bazinga.ttf"]` and `theme B` lists `["$path/somefont.ttf", "$path/lol.otf"]`, only the latter font from `theme B` will get loaded

Something somewhat related that i think would be good, but this PR doesnt adress, is to let themes change the font family used for the `<alt>` alternian font tags. Currently thats hardcoded, but because the code that generates the rich text that displays that font is burried in the lexer i didn't see an instantly obvious way to accomplish this, since it would need access to the current theme variable, which the lexer does not