### PR TITLE
Fix ostools.getDataDir() returning different path after initialisation

### DIFF
--- a/ostools.py
+++ b/ostools.py
@@ -8,6 +8,7 @@ except ImportError:
     print("PyQt5 fallback (ostools.py)")
     from PyQt5.QtCore import QStandardPaths
 
+DATADIR = None
 
 def isOSX():
     return sys.platform == "darwin"
@@ -75,6 +76,18 @@ def getDataDir():
     # Temporary fix for non-ascii usernames
     # If username has non-ascii characters, just store userdata
     # in the Pesterchum install directory (like before)
+
+    if DATADIR is not None:
+        # ~Lisanne
+        # On some systems (windows known 2b affected, OSX unknown, at least 1 linux distro unaffected)
+        # the QStandardPaths.writableLocation changes its return path after the QApplication initialises
+        # This means that anytime its called during runtime after init will just return a lie. it will just give you a different path
+        # (Because the Application now has a Name which in turn makes it return an application-name-specific writableLocation, which pchum isnt expecting anywhere)
+        # so
+        # here im caching the result at init & returning that 
+        # seemed like the safest way to do this without breaking half of this program
+        return DATADIR
+    
     try:
         if isOSX():
             return os.path.join(
@@ -100,3 +113,5 @@ def getDataDir():
     except UnicodeDecodeError as e:
         print(e)
         return ""
+
+DATADIR = getDataDir()


### PR DESCRIPTION
getDataDir() now runs once when ostools gets imported, caches that output, & returns that on every call to getDataDir() from then on.
Fixes calling getDataDir() returning a different unexpected path after the initialisation of QApplication bumps the priority list to `%appdata%/Pesterchum,` resulting in a returned path of `%appdata%/Pesterchum/pesterchum`.

This is only known to be a problem on Windows, macOS is unknown & maybe some linux distros have the same problem, but my local machine had no issues.

theres probably a more elegant solution, but this seemed like one thats least prone to cause weird unexpected behavior in other parts of pesterchum