### PR TITLE
URL encode spaces in moodmsg icon paths

### DIFF
--- a/dataobjs.py
+++ b/dataobjs.py
@@ -375,14 +375,14 @@ class PesterProfile:
 
     def moodmsg(self, mood, syscolor, theme):
         return (
-            "<c=%s>-- %s <c=%s>[%s]</c> changed their mood to %s <img src='%s' /> --</c>"
+            '<c=%s>-- %s <c=%s>[%s]</c> changed their mood to %s <img src="%s" /> --</c>'
             % (
                 syscolor.name(),
                 self.handle,
                 self.colorhtml(),
                 self.initials(),
                 mood.name().upper(),
-                theme["main/chums/moods"][mood.name()]["icon"],
+                theme["main/chums/moods"][mood.name()]["icon"].replace(" ", "%20"),
             )
         )
 


### PR DESCRIPTION
Replace spaces with %20 in dataobj's `<img src="(path)" />`, used for showing the "X changed changed their mood to Y <icon>" message.
this would fail if the current theme has a space anywhere in its absolute path. QT is quirky 