### PR TITLE
fixed RE bot not being told about preference on connect

### DIFF
--- a/randomer.py
+++ b/randomer.py
@@ -28,9 +28,12 @@ class RandomHandler(QtCore.QObject):
         self.queue.append("?")
         self.mainwindow.sendNotice.emit("?", self.randNick)
 
-    def setRandomer(self, r):
-        if r != self.mainwindow.userprofile.getRandom():
-            if r:
+    def setRandomer(self, value, force=False):
+        # Notifies randomEncounter of our preferences
+        # Only does so if the new value differs from what is stored in userprofile
+        # Can be forced to notify anyways by providing `force=True`
+        if value != self.mainwindow.userprofile.getRandom() or force:
+            if value:
                 code = "+"
             else:
                 code = "-"


### PR DESCRIPTION
Client now properly tells randomEncounter bot about its status as stored in the profile
The code for this existed previously, but was ran at window init which happens before the connection is even started i believe.
ive moved it to the `connected` function which connects from the irc thread & triggers when the welcome message is received
tested for a bit on scratchware and seems to work as intended
the only thing that it still does not handle is if the bot restarts while the client is connected, but this is a rare event so itll be fine probs