### PR TITLE
Sort theme list case-insensitively

### DIFF
--- a/user_profile.py
+++ b/user_profile.py
@@ -567,7 +567,7 @@ with a backup from: <a href='%s'>%s</a></h3></html>"
                 for d in dirnames:
                     if d not in themes:
                         themes.append(d)
-        themes.sort()
+        themes.sort(key=str.casefold)
         return themes
 
     def availableProfiles(self):


### PR DESCRIPTION
makes the theme list not get split between Capitalnames and lowernames, like Trollian and trollian.