### PR TITLE
fix metadata moods with index > 9 displaying incorrectly + remove valid chumhandle check for blocklist & chumroll adding

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -589,12 +589,10 @@ class PesterIRC(QtCore.QThread):
         METADATA <Target> <Key> <Visibility> <Value>
         """
         if key.casefold() == "mood":
-            if is_valid_mood(value[0]):
-                mood = Mood(int(value[0]))
+            if is_valid_mood(value):
+                mood = Mood(int(value))
             else:
-                PchumLog.warning(
-                    "Mood index '%s' from '%s' is not valid.", value[0], nick
-                )
+                PchumLog.warning("Mood index '%s' from '%s' is not valid.", value, nick)
                 mood = Mood(0)
             self.moodUpdated.emit(nick, mood)
         elif key.casefold() == "color":
@@ -1085,7 +1083,7 @@ class PesterIRC(QtCore.QThread):
             )
 
     def _sasl_skill_issue(self, *_msg):
-        """Handles all responses from server that indicate SASL authentication failed.
+        """Handles all responses from server that indicate SASL authentication failed.
 
         Replies that indicate we can't authenticate include: 902, 904, 905.
         Aborts SASL by sending CAP END, ending capability negotiation."""

--- a/mood.py
+++ b/mood.py
@@ -61,6 +61,7 @@ class Mood:
     }
 
     def __init__(self, mood):
+        # self.mood: integer value of the mood
         if isinstance(mood, int):
             self.mood = mood
         else:
@@ -100,52 +101,63 @@ class PesterMoodAction(QtCore.QObject):
 
 
 class PesterMoodHandler(QtCore.QObject):
-    def __init__(self, parent, *buttons):
+    def __init__(self, parent, buttons):
         QtCore.QObject.__init__(self)
         self.buttons = {}
         self.mainwindow = parent
-        for b in buttons:
-            self.buttons[b.mood.value()] = b
-            if b.mood.value() == self.mainwindow.profile().mood.value():
-                b.setSelected(True)
-            b.clicked.connect(b.updateMood)
-            b.moodUpdated[int].connect(self.updateMood)
+        for button in buttons:
+            # for each button:
+            # map its mood index (IE, 3) to its button object
+            self.buttons[button.mood.value()] = button
+            # check if the buttons mood is the current users's mood
+            if button.mood.value() == self.mainwindow.profile().mood.value():
+                # make it selected if yes
+                button.setSelected(True)
+            # Make clicking the button actually do something
+            # (note that the only thing button.updateMood does is emit button.moodUpdated with the button's mood index)
+            button.clicked.connect(button.updateMood)
+            button.moodUpdated[int].connect(self.updateMood)
 
     def removeButtons(self):
-        for b in list(self.buttons.values()):
-            b.close()
+        for button in list(self.buttons.values()):
+            button.close()
 
     def showButtons(self):
-        for b in list(self.buttons.values()):
-            b.show()
-            b.raise_()
+        for button in list(self.buttons.values()):
+            button.show()
+            button.raise_()
 
     @QtCore.pyqtSlot(int)
-    def updateMood(self, m):
+    def updateMood(self, mood_index):
         # update MY mood
+        # Currently set, soon to be replaced mood of our user
         oldmood = self.mainwindow.profile().mood
-        try:
-            oldbutton = self.buttons[oldmood.value()]
-            oldbutton.setSelected(False)
-        except KeyError:
-            pass
-        try:
-            newbutton = self.buttons[m]
-            newbutton.setSelected(True)
-        except KeyError:
-            pass
-        newmood = Mood(m)
-        self.mainwindow.userprofile.chat.mood = newmood
-        self.mainwindow.userprofile.setLastMood(newmood)
+
+        # Grab previous mood button (if it exists), set it to not be selected anymore
+        if oldmood.value() in self.buttons:
+            self.buttons[oldmood.value()].setSelected(False)
+        # Grab the moodbutton that corrosponds to the new index (if it exists), set it to be selected
+        if mood_index in self.buttons:
+            self.buttons[mood_index].setSelected(True)
+
+        newmood = Mood(mood_index)
+        self.mainwindow.userprofile.chat.mood = (
+            newmood  # changes current mood directly (?)
+        )
+        self.mainwindow.userprofile.setLastMood(
+            newmood
+        )  # mood saved to the user .js config to be used next time we start up
         if self.mainwindow.currentMoodIcon:
             moodicon = newmood.icon(self.mainwindow.theme)
             self.mainwindow.currentMoodIcon.setPixmap(
                 moodicon.pixmap(moodicon.realsize())
             )
+        # If the mood value has changed at all
         if oldmood.name() != newmood.name():
-            for c in list(self.mainwindow.convos.values()):
-                c.myUpdateMood(newmood)
-        self.mainwindow.moodUpdated.emit()
+            for conversation in list(self.mainwindow.convos.values()):
+                conversation.myUpdateMood(newmood)
+        self.mainwindow.moodUpdated.emit()  # Global signal to tell the rest of the application our mood changed.
+        # why does PesterMoodHandler cause an emit of a signal on mainwindow? who knows.
 
 
 class PesterMoodButton(QtWidgets.QPushButton):

--- a/pesterchum.py
+++ b/pesterchum.py
@@ -798,6 +798,7 @@ class chumArea(RightClickTree):
     def updateMood(self, handle, mood):
         hideoff = self.mainwindow.config.hideOfflineChums()
         chums = self.getChums(handle)
+        # Grab all the chums from the chumroll that matches the handle (duplicates are possible)
         oldmood = None
         if hideoff:
             if (
@@ -818,14 +819,18 @@ class chumArea(RightClickTree):
                     # self.takeItem(c)
                 chums = []
         for c in chums:
+            # For each instance of the handle on the chumroll, change their displayed mood
             if hasattr(c, "mood"):
                 oldmood = c.mood
                 c.setMood(mood)
+
         if self.mainwindow.config.sortMethod() == 1:
+            # uh. uhmm. uhh. uhhhh.
             for i in range(self.topLevelItemCount()):
                 saveCurrent = self.currentItem()
                 self.moodSort(i)
                 self.setCurrentItem(saveCurrent)
+            # yeah idk what this does ↑
         if self.mainwindow.config.showOnlineNumbers():
             self.showOnlineNumbers()
         return oldmood
@@ -1200,10 +1205,8 @@ class TrollSlumWindow(QtWidgets.QFrame):
             self, "Add Troll", "Enter Troll Handle:"
         )
         if ok:
-            if not (
-                PesterProfile.checkLength(handle)
-                and PesterProfile.checkValid(handle)[0]
-            ):
+            # TODO MAYBE: Perhaps check PesterProfile.checkValid(handle)[0] & add a confirmation witha little "you may have missed a capital letter r u sure" if its invalid
+            if not (PesterProfile.checkLength(handle)):
                 errormsg = QtWidgets.QErrorMessage(self)
                 errormsg.showMessage("THIS IS NOT A VALID CHUMTAG!")
                 self.addchumdialog = None
@@ -1899,8 +1902,10 @@ class PesterWindow(MovingWindow):
         self.chumdb.setColor(handle, color)
 
     def updateMood(self, handle, mood):
-        # updates OTHER chums' moods
-        oldmood = self.chumList.updateMood(handle, mood)
+        # updates OTHER (but also ours if we're on our own chumroll) chums' moods
+        oldmood = self.chumList.updateMood(
+            handle, mood
+        )  # This calls chumArea.updateMood
         if handle in self.convos:
             self.convos[handle].updateMood(mood, old=oldmood)
         if hasattr(self, "trollslum") and self.trollslum:
@@ -2122,9 +2127,11 @@ class PesterWindow(MovingWindow):
         if self.moods:
             self.moods.removeButtons()
         mood_list = theme["main/moods"]
-        mood_list = [{str(k): v for (k, v) in d.items()} for d in mood_list]
         self.moods = PesterMoodHandler(
-            self, *[PesterMoodButton(self, **d) for d in mood_list]
+            self,
+            [
+                PesterMoodButton(self, **mood) for mood in mood_list
+            ],  # For mood dict in mood_list, create a matching PesterMoodButton
         )
         self.moods.showButtons()
         # chum
@@ -2465,8 +2472,8 @@ class PesterWindow(MovingWindow):
 
     @QtCore.pyqtSlot(str, Mood)
     def updateMoodSlot(self, handle, mood):
-        h = handle
-        self.updateMood(h, mood)
+        # Called by IRC for each handle that updates its mood, either through #pesterchum or metadata
+        self.updateMood(handle, mood)
 
     @QtCore.pyqtSlot(str, QtGui.QColor)
     def updateColorSlot(self, handle, color):
@@ -2642,10 +2649,8 @@ class PesterWindow(MovingWindow):
                 if handle in [h.handle for h in self.chumList.chums]:
                     self.addchumdialog = None
                     return
-                if not (
-                    PesterProfile.checkLength(handle)
-                    and PesterProfile.checkValid(handle)[0]
-                ):
+                # TODO MAYBE: Perhaps check PesterProfile.checkValid(handle)[0] & add a confirmation witha little "you may have missed a capital letter r u sure" if its invalid
+                if not (PesterProfile.checkLength(handle)):
                     errormsg = QtWidgets.QErrorMessage(self)
                     errormsg.showMessage("THIS IS NOT A VALID CHUMTAG!")
                     self.addchumdialog = None
@@ -2707,10 +2712,9 @@ class PesterWindow(MovingWindow):
 
     @QtCore.pyqtSlot(str)
     def unblockChum(self, handle):
-        h = handle
-        self.config.delBlocklist(h)
-        if h in self.convos:
-            convo = self.convos[h]
+        self.config.delBlocklist(handle)
+        if handle in self.convos:
+            convo = self.convos[handle]
             msg = self.profile().pestermsg(
                 convo.chum,
                 QtGui.QColor(self.theme["convo/systemMsgColor"]),
@@ -2719,7 +2723,7 @@ class PesterWindow(MovingWindow):
             convo.textArea.append(convertTags(msg))
             self.chatlog.log(convo.chum.handle, msg)
             convo.updateMood(convo.chum.mood, unblocked=True)
-        chum = PesterProfile(h, chumdb=self.chumdb)
+        chum = PesterProfile(handle, chumdb=self.chumdb)
         if hasattr(self, "trollslum") and self.trollslum:
             self.trollslum.removeTroll(handle)
         self.config.addChum(chum)


### PR DESCRIPTION
moods set over metadata higher than 9 would only get their first character read (12 → 1), which is now fixed

also removed a restriction that prevented you from entering an invalid chumroll for new entries on the chumroll or blocklist, which is sometimes the case when you were adding users on a different non-pesterchum client. Adding them was already possible from the right-click menu but not in the "add X popups"

also sprinkled some extra comments & expanded some variable names to be more sane