### PR TITLE
Fix `"theme/item" in theme` checks for theme scrollbars

### DIFF
--- a/pesterchum.py
+++ b/pesterchum.py
@@ -840,7 +840,8 @@ class chumArea(RightClickTree):
         self.move(*theme["main/chums/loc"])
         if "main/chums/scrollbar" in theme:
             self.setStyleSheet(
-                "QListWidget { %s } \
+                "RightClickTree { %s } \
+                QListWidget { %s } \
                 QScrollBar { %s } \
                 QScrollBar::handle { %s } \
                 QScrollBar::add-line { %s } \
@@ -848,6 +849,7 @@ class chumArea(RightClickTree):
                 QScrollBar:up-arrow { %s } \
                 QScrollBar:down-arrow { %s }"
                 % (
+                    theme["main/chums/style"], # This is kind of hacky, but without it chumrolls dont get styled when u set a scrollbar
                     theme["main/chums/style"],
                     theme["main/chums/scrollbar/style"],
                     theme["main/chums/scrollbar/handle"],

--- a/user_profile.py
+++ b/user_profile.py
@@ -1049,6 +1049,10 @@ class pesterTheme(dict):
             else:
                 return default
 
+    def __contains__(self, key):
+        # Allows for `"thing/other/thing" in theme` checking
+        return self.has_key(key)
+
     def has_key(self, key):
         keys = key.split("/")
         try:


### PR DESCRIPTION
Because PesterTheme inherits Dictionary but does not overwrite `__contains__()`, these would always return `False`.
this made overwriting the default scrollbars on stuff like log text impossible. i've checked a couple of built-in themes and they still seem to work fine, so probably this bug was introduced a while after those were all made.