### PR TITLE
set accept header for embed requests & allow webps and gifs

### DIFF
--- a/embeds.py
+++ b/embeds.py
@@ -90,7 +90,7 @@ class EmbedsManager(QtCore.QObject):
         # Track which embeds are downloading so we dont do double-fetches
 
         self.embed_loading.emit(url)
-        reply = get_request(url)
+        reply = get_request(url, {"Accept": "image/*, */*;q=0.8"})
         reply.finished.connect(lambda: self._on_request_finished(reply, url))
 
     def _on_request_finished(self, reply, url):

--- a/parsetools.py
+++ b/parsetools.py
@@ -45,7 +45,7 @@ _alternian_end = re.compile(r"</alt>")
 
 
 _embedre = re.compile(
-    r"(?i)(?:^|(?<=\s))(?:(?:https?):\/\/)[^\s]+(?:\.png|\.jpg|\.jpeg)(?:\?[^\s]+)?"
+    r"(?i)(?:^|(?<=\s))(?:(?:https?):\/\/)[^\s]+(?:\.png|\.jpg|\.jpeg|\.gif|\.webp)(?:\?[^\s]+)?"
 )
 
 

--- a/theme_repo_manager.py
+++ b/theme_repo_manager.py
@@ -65,9 +65,11 @@ userAgent = "Mozilla/5.0 (X11; Linux x86_64; rv:122.0) Gecko/20100101 Firefox/12
 # these are here because we connect the reply finished() signal to lambdas later on
 # and APPARENTLY they get garbage collected & never trigger if your code leaves the scope before it finishes downloading
 # which is basically always unless the file is like 0.001kb. anyways. evil pyqt
-def get_request(url):
+def get_request(url, extra_headers={}):
     request = QtNetwork.QNetworkRequest(QtCore.QUrl(url))
     request.setRawHeader(b"User-Agent", userAgent.encode())
+    for name, value in extra_headers.items():
+        request.setRawHeader(str(name).encode(), str(value).encode())
     reply = networkManager.get(request)
     # Add to downloads set to prevent GC until its finished
     downloads.add(reply)


### PR DESCRIPTION
Very small changes that add a `Accept:` header to requests for embeds with a value of `image/*, */*;q=0.8`, which tells the server we expect an image (or anything else with a lower priority)

also adds webp & gifs to the lexer so that they can get embedded. no clue if webps actually can get loaded with the QT libraries, and gifs only load static frames at the moment.

Changing that to also animate would require using `PesterMovie` with `PesterText.addAnimation` somewhere, though i haven't looked into it yet, so thats a TODO. if thats implemented it may also cause more lag with how weirdly gifs are handled in pesterchum but idk. something to look into for the future and out of scope for this.